### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Jamf-Concepts/terraform-provider-jsctfprovider/security/code-scanning/1](https://github.com/Jamf-Concepts/terraform-provider-jsctfprovider/security/code-scanning/1)

To fix this problem, add a `permissions` block at the workflow root (at the same indentation level as `name` and `on`) or at the job level if only specific jobs require reduced permissions. Since the workflow as shown is entirely read-only and does not interact with the repository in ways that require writing, we can safely restrict the token permissions to `contents: read`. This change should be added at the root of `.github/workflows/go.yml` before the `jobs:` block (e.g., after the `name` and `on` sections). No new methods, imports, or definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
