### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -36,7 +36,7 @@ var protectDomainname string
 func AuthenticateProtect(domainname string, clientid string, clientpassword string) error {
 
 	authpayload := "{\"client_id\": \"" + clientid + "\", \"password\": \"" + clientpassword + "\"}"
-	fmt.Println("Payload for auth  creating request:", authpayload)
+	fmt.Printf("Payload for auth creating request: client_id=%s, password=[REDACTED]\n", clientid)
 	url := fmt.Sprintf("https://%s/token", domainname)
 
 	req, err := http.NewRequest("POST", url, strings.NewReader(authpayload))


### PR DESCRIPTION
Potential fix for [https://github.com/Jamf-Concepts/terraform-provider-jsctfprovider/security/code-scanning/2](https://github.com/Jamf-Concepts/terraform-provider-jsctfprovider/security/code-scanning/2)

Sensitive information such as user passwords must never be logged, even for debugging. The best way to fix this issue is to remove the logging of sensitive details from the code. We should change the line printing `authpayload` so that it either does not log the payload at all, or logs a sanitized/masked version (e.g., "[REDACTED]" in place of the password). In most cases, logging the fact that the payload is being sent, along with non-sensitive info such as client ID, suffices for debugging without exposing secrets.

Thus, **in internal/auth/auth.go**, line 39 should be modified to not log the full payload. The recommended fix is to change this line to something like:
```go
fmt.Printf("Payload for auth creating request: client_id=%s, password=[REDACTED]\n", clientid)
```
Alternatively, for even less exposure, the log can be entirely removed if not needed.

No new methods, imports, or definitions are required. Only line 39 (the logging statement) needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
