### PR TITLE
fix(auth): surface real RADAR auth failures instead of masking them

### DIFF
--- a/endpoints/activationprofiles/resource_activationprofiles.go
+++ b/endpoints/activationprofiles/resource_activationprofiles.go
@@ -624,7 +624,7 @@ func resourceAPCreate(d *schema.ResourceData, m interface{}) error {
 	resp, err := auth.MakeRequest((req))
 
 	if err != nil {
-		return fmt.Errorf("an error occurred: %s", "additional information3")
+		return fmt.Errorf("an error occurred: %s", err.Error())
 	}
 	defer resp.Body.Close()
 	// Check the response status code

--- a/endpoints/blockpages/resource_blockpage.go
+++ b/endpoints/blockpages/resource_blockpage.go
@@ -105,7 +105,7 @@ func resourceBlockPageCreate(d *schema.ResourceData, m interface{}) error {
 	resp, err := auth.MakeRequest((req))
 
 	if err != nil {
-		return fmt.Errorf("an error occurred: %s", "additional information3")
+		return fmt.Errorf("an error occurred: %s", err.Error())
 	}
 	defer resp.Body.Close()
 	// Check the response status code

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -187,6 +187,10 @@ func AuthenticateRadarAPI(DomainName string, Username string, Password string, C
 		}
 	}
 
+	if sessionCookie == "" {
+		return fmt.Errorf("RADAR authentication succeeded (HTTP %s) but no SESSION cookie was returned", resp.Status)
+	}
+
 	if Customerid == "empty" {
 		//Customerid not provided so attempt to find from endpiint
 		findCustomerid(DomainName)


### PR DESCRIPTION
## Summary

Fixes two related failures that reproduced 100% of the time on the first live end-to-end run of the Jamf Foundations onboarder (`jamf/modular_onboarder`) against this provider:

```
Error: an error occurred: additional information3
  with module.configuration-jamf-security-cloud-all-services[0].jsc_ap.all_services

Error: error RADAR API not authenticated
  with module.configuration-jamf-security-cloud-jamf-pro[0].jsc_uemc.initial_uemc
```

## Root cause

The original triage suspected blank `jsc_username`/`jsc_password` (they're optional fields in the onboarder's own config), since `main.go`'s `providerConfigure` only calls `AuthenticateRadarAPI` when `Username != ""`. That theory was ruled out — the credentials used for the live run were confirmed non-blank.

The actual bug is in `AuthenticateRadarAPI` (`internal/auth/auth.go`): after the local-auth login POST succeeds, it scans the response cookies for one named `SESSION` and assigns it to the package-level `sessionCookie`, but returns `nil` (success) unconditionally — even if no `SESSION` cookie was present in the response. `sessionCookie` then stays `""` for the lifetime of the provider instance, and the real failure only surfaces later, opaquely, when the next RADAR-backed resource calls `MakeRequest`, which checks `if sessionCookie == ""` and returns `"error RADAR API not authenticated"` — exactly the error above, with no indication *why* auth didn't take.

`jsc_ap`'s create path (`endpoints/activationprofiles/resource_activationprofiles.go`) made this worse by swallowing the real error from `auth.MakeRequest` and returning a placeholder string, `"additional information3"`, instead — masking what was almost certainly the same underlying `sessionCookie == ""` condition, one resource earlier. `resource_blockpage.go` has the identical placeholder on the identical `auth.MakeRequest` failure path. (`resource_ztna.go` had the same pattern historically but has since been cleaned up on `main` to already return `err.Error()` there — no change needed in that file.)

Checked whether the placeholder was intentionally hiding something sensitive in the underlying error (credentials, tokens, etc.) — it isn't. `MakeRequest`'s possible errors are all generic transport-layer strings (the sentinel `"error RADAR API not authenticated"`, a body-read error, the raw `net/http` client error, or a retry-exhaustion message) and the response body is never echoed into the error. The surrounding file is full of these numbered placeholders (`"additional information1/2/4"` alongside `3`) at nearly every error check, which reads like debug scaffolding that was never replaced with real error propagation before merging, not a deliberate security decision.

## Fix

- `AuthenticateRadarAPI` now returns an explicit error immediately if no `SESSION` cookie comes back from the local-auth login response, instead of silently succeeding. This makes a RADAR auth failure fail loudly and diagnosably at `providerConfigure` time, rather than masquerading as an opaque failure on a downstream resource. (The newer `AuthenticateViaJamfID` SSO fallback path is unaffected — it sets `sessionCookie` directly and returns before reaching this check.)
- Replaced the placeholder `"additional information3"` string in `resource_activationprofiles.go` and `resource_blockpage.go` with `err.Error()`, so the real underlying error from `auth.MakeRequest` reaches Terraform instead of being discarded.

Note: this fix makes the *symptom* diagnosable — it doesn't establish why the login response lacked a `SESSION` cookie for this tenant/credential combination in the first place. That's a live-run question to chase once this lands (bad credential scope? unexpected auth response shape for this tenant?).

Other placeholder strings in these files (`"additional information1/2/4"`) were left untouched — only the ones on the traced path were in scope here.

## Testing

- `go build ./...` passes.
- `go vet ./...` has one pre-existing, unrelated failure in `endpoints/uemc/resource_uemc.go` (a `Printf`-formatting-directive lint) that predates this branch.
- Not yet re-verified against a live tenant — a live re-run will confirm the auth failure now surfaces with an actionable message (or resolves outright, if the underlying cause is something this fix incidentally routes around).

## Related

Part of a 3-repo fix set for the Jamf Foundations onboarder's first live-run failures. See `jamf/modular_onboarder`'s `dev-docs/jamfplatform-provider-terraform-apply-failures.md` for the full failure catalogue and triage notes.