### PR TITLE
fix: update provider source and version in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Create a `main.tf`. You will not need to `terraform init` when using the above o
 terraform {
   required_providers {
     jsc = {
-      source  = "jsctf"
-      version = "1.0.0"
+      source  = "Jamf-Concepts/jsctfprovider"
+      version = "~> 0.1.6"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,8 @@ description: |-
 terraform {
   required_providers {
     jsc = {
-      source  = "jsctf"
-      version = "1.0.0"
+      source  = "Jamf-Concepts/jsctfprovider"
+      version = "~> 0.1.6"
     }
 
   }


### PR DESCRIPTION
Corrects the registry source from the local dev override "jsctf" to the published Hashicorp Registry path "Jamf-Concepts/jsctfprovider" and updates the version constraint to "~> 0.1.6". Fixes #162.