### PR TITLE
fix(uemc): surface actual response body in create/read errors

### DIFF
--- a/endpoints/uemc/resource_uemc.go
+++ b/endpoints/uemc/resource_uemc.go
@@ -89,15 +89,15 @@ func resourceUEMCCreate(d *schema.ResourceData, m interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	// Check the response status code
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != 200 {
-		return fmt.Errorf("failed to create UEMC Connection: %s", resp.Status+" "+string(payload))
-	}
-
 	// Read the response body
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
+	}
+
+	// Check the response status code
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != 200 {
+		return fmt.Errorf("failed to create UEMC Connection: %s - %s", resp.Status, string(body))
 	}
 
 	// Parse the response JSON
@@ -134,15 +134,15 @@ func resourceUEMCRead(d *schema.ResourceData, m interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	// Check the response status code
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to read UEMC info: %s", resp.Status)
-	}
-
 	// Read the response body
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
+	}
+
+	// Check the response status code
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to read UEMC info: %s - %s", resp.Status, string(body))
 	}
 
 	// Parse the response JSON and extract the ID


### PR DESCRIPTION
## Summary
- `resourceUEMCCreate` echoed the outgoing *request* payload back as error detail instead of RADAR's response body — the true error was never visible.
- `resourceUEMCRead` reported only the status code, no body at all.
- Both now read and include the actual response body in the returned error.

## Why
Discovered while live-testing the Jamf Foundations onboarder against a `letstest.jamfcloud.com` test tenant: a UEMC creation 500 was reported with zero actionable detail. After patching in temporary debug logging, the real body turned out to be a genuine RADAR/`emm-server` backend error (`INTERNAL_SERVER_ERROR` with a `logref`) — useful info that was being silently discarded before this fix.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] Verified live: re-ran `terraform apply -target=...jsc_uemc.initial_uemc` against `letstest.jamfcloud.com` with a locally-built binary via `dev_overrides` — the error now reads `500 Internal Server Error - {"message":"Internal Server Error","error":"INTERNAL_SERVER_ERROR","logref":"...","statusCode":500}` instead of echoing the request payload.