### PR TITLE
fix: suppress case-only diffs on jsc_ap idptype to stop perpetual replace

### DIFF
--- a/endpoints/activationprofiles/resource_activationprofiles.go
+++ b/endpoints/activationprofiles/resource_activationprofiles.go
@@ -525,7 +525,10 @@ func ResourceActivationProfile() *schema.Resource {
 				ValidateFunc: validateIdP,
 				Default:      "None",
 				ForceNew:     true,
-				Description:  "Allowed values of 'Okta', 'None, or 'NetworkRelay'. If NetworkRelay is selected, only Private Access will be enabled",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
+				Description: "Allowed values of 'Okta', 'None, or 'NetworkRelay'. If NetworkRelay is selected, only Private Access will be enabled",
 			},
 			"oktaconnectionid": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
## Summary
- `jsc_ap.all_services` (and any `jsc_ap` resource) was showing `must be replaced` on every single `terraform plan`, forever, even right after a clean apply.
- Root cause: `idptype` is `ForceNew`, and its validator (`validateIdP`) treats casing as insensitive (`"NONE"`, `"None"`, `"none"` all valid). But the Read function always normalizes the value it writes back to state to title case (e.g. `"None"`). If a config uses different casing than that normalized form, every refresh sees a diff on a `ForceNew` field and forces a full replace — which never resolves since Read keeps writing the normalized casing back.
- Fix: added a `DiffSuppressFunc` on `idptype` doing a case-insensitive comparison, matching the validator's own intent.

## Verification
Live-tested against a real tenant (`terraform-jamf-platform`'s `configuration-jamf-security-cloud-all-services` module, which configures `idptype = "NONE"`) using a local dev override:
- Before: `tofu plan` showed `idptype = "None" -> "NONE" # forces replacement`, `Plan: 1 to add, 0 to change, 1 to destroy` every time.
- After: `tofu plan` → `No changes. Your infrastructure matches the configuration.`

## Test plan
- [ ] `go build ./...` / `go vet ./...` pass (done locally)
- [ ] Existing acceptance tests for `jsc_ap` still pass
- [ ] Confirm no regression for configs that intentionally change `idptype` (e.g. `"None"` → `"Okta"`) — that should still force a replace, since the values are genuinely different case-insensitively too