### PR TITLE
fix(uemc): self-heal on read when RADAR config was deleted out-of-band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed `jsc_uemc` read treating an empty RADAR config list as a hard error; now clears the resource ID so Terraform recreates it when the config was deleted out-of-band (e.g. by a tenant wipe outside Terraform)
+
 ## v0.1.8
 
 - Fixed `jsc_ap` `idptype` causing perpetual replace on case-only diffs

--- a/endpoints/uemc/resource_uemc.go
+++ b/endpoints/uemc/resource_uemc.go
@@ -151,8 +151,19 @@ func resourceUEMCRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	if len(configsResp.Configs) == 0 {
-		return fmt.Errorf("no configs found in response")
+	// If this resource's config is no longer present in RADAR (e.g. deleted
+	// out-of-band, such as by a tenant wipe that doesn't go through Terraform),
+	// treat it as gone rather than erroring the whole apply/refresh: clear the
+	// ID so Terraform knows to recreate it.
+	found := false
+	for _, c := range configsResp.Configs {
+		if c.ID == d.Id() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		d.SetId("")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- `resourceUEMCRead` hard-errored (`no configs found in response`) whenever RADAR's config list didn't contain this resource's id — including the common case where the config was deleted outside Terraform (e.g. a tenant wipe not run through Terraform).
- Now checks whether this resource's specific id is present in the returned config list; if not, clears the resource ID (`d.SetId("")`) so Terraform recreates it on the next apply, instead of failing the whole apply/refresh.

## Found via
Live testing against a dedicated test tenant (`letstest.jamfcloud.com`): a `jsc_uemc` resource in Terraform state pointed at a RADAR config that had been removed by an earlier "Wipe Entire Tenant" pass. `TF_LOG=DEBUG` confirmed the read request itself was correct (customerId-scoped GET, 200 response) — the response body just legitimately had zero configs, and the old code treated that as fatal instead of "not found."

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt` clean on the changed file
- [x] Live-verified: removed the stale resource from state, ran a fresh `tofu apply` against the test tenant, confirmed `jsc_uemc` recreated cleanly
- [ ] No existing test file for this package (`endpoints/uemc`) to extend — none of the other endpoint packages have test files either, so no new test scaffolding was added to stay consistent with current convention